### PR TITLE
Pin hdf5 to avoid conflicts

### DIFF
--- a/.ci_support/linux_64_mpimpich.yaml
+++ b/.ci_support/linux_64_mpimpich.yaml
@@ -14,8 +14,6 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '7'
-hdf5:
-- 1.10.6
 libblas:
 - 3.8 *netlib
 libcblas:

--- a/.ci_support/linux_64_mpinompi.yaml
+++ b/.ci_support/linux_64_mpinompi.yaml
@@ -14,8 +14,6 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '7'
-hdf5:
-- 1.10.6
 libblas:
 - 3.8 *netlib
 libcblas:

--- a/.ci_support/linux_aarch64_mpimpich.yaml
+++ b/.ci_support/linux_aarch64_mpimpich.yaml
@@ -20,8 +20,6 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - 7.5.0
-hdf5:
-- 1.10.6
 libblas:
 - 3.8 *netlib
 libcblas:

--- a/.ci_support/linux_aarch64_mpinompi.yaml
+++ b/.ci_support/linux_aarch64_mpinompi.yaml
@@ -20,8 +20,6 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - 7.5.0
-hdf5:
-- 1.10.6
 libblas:
 - 3.8 *netlib
 libcblas:

--- a/.ci_support/linux_ppc64le_mpimpich.yaml
+++ b/.ci_support/linux_ppc64le_mpimpich.yaml
@@ -14,8 +14,6 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '8'
-hdf5:
-- 1.10.6
 libblas:
 - 3.8 *netlib
 libcblas:

--- a/.ci_support/linux_ppc64le_mpinompi.yaml
+++ b/.ci_support/linux_ppc64le_mpinompi.yaml
@@ -14,8 +14,6 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '8'
-hdf5:
-- 1.10.6
 libblas:
 - 3.8 *netlib
 libcblas:

--- a/.ci_support/osx_64_mpimpich.yaml
+++ b/.ci_support/osx_64_mpimpich.yaml
@@ -14,8 +14,6 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '7.5'
-hdf5:
-- 1.10.6
 libblas:
 - 3.8 *netlib
 libcblas:

--- a/.ci_support/osx_64_mpinompi.yaml
+++ b/.ci_support/osx_64_mpinompi.yaml
@@ -14,8 +14,6 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '7.5'
-hdf5:
-- 1.10.6
 libblas:
 - 3.8 *netlib
 libcblas:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "mpb" %}
 {% set version = "1.10.0" %}
 {% set sha256 = "3cd3366aca40eacb8fc01476adfd9e376fd0f81ef6109cef4f85b15218a3514f" %}
-{% set buildnumber = 10 %}
+{% set buildnumber = 11 %}
 
 # recipe-lint fails if mpi is undefined
 {% set mpi = mpi or 'nompi' %}
@@ -48,11 +48,12 @@ requirements:
     - libcblas
     - liblapack
     - fftw
-    - hdf5
+    - hdf5 1.10.5
     - libctl >=4.5.0
   run:
     - {{ mpi }}  # [mpi != 'nompi']
     - fftw
+    - hdf5 1.10.5
     - libctl >=4.5.0
     - zlib
     - _openmp_mutex  # [linux]


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

Pin `hdf5` to 1.10.5 since `h5utils` (a dep of `pymeep`) has a constraint of `hdf5<1.10.6a0`.
