### PR TITLE
Re-render (last deploy failed randomly).

### DIFF
--- a/.scripts/logging_utils.sh
+++ b/.scripts/logging_utils.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# Provide a unified interface for the different logging
+# utilities CI providers offer. If unavailable, provide
+# a compatible fallback (e.g. bare `echo xxxxxx`).
+
+function startgroup {
+    # Start a foldable group of log lines
+    # Pass a single argument, quoted
+    case ${CI:-} in
+        azure )
+            echo "##[group]$1";;
+        travis )
+            echo "$1"
+            echo -en 'travis_fold:start:'"${1// /}"'\\r';;
+        * )
+            echo "$1";;
+    esac
+}
+
+function endgroup {
+    # End a foldable group of log lines
+    # Pass a single argument, quoted
+    case ${CI:-} in
+        azure )
+            echo "##[endgroup]";;
+        travis )
+            echo -en 'travis_fold:end:'"${1// /}"'\\r';;
+    esac
+}

--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -5,6 +5,10 @@
 # changes to this script, consider a proposal to conda-smithy so that other feedstocks can also
 # benefit from the improvement.
 
+source .scripts/logging_utils.sh
+
+startgroup "Configure Docker"
+
 set -xeo pipefail
 
 THISDIR="$( cd "$( dirname "$0" )" >/dev/null && pwd )"
@@ -65,7 +69,9 @@ DOCKER_RUN_ARGS="${CONDA_FORGE_DOCKER_RUN_ARGS}"
 if [ -z "${CI}" ]; then
     DOCKER_RUN_ARGS="-it ${DOCKER_RUN_ARGS}"
 fi
+endgroup "Configure Docker"
 
+startgroup "Start Docker"
 export UPLOAD_PACKAGES="${UPLOAD_PACKAGES:-True}"
 docker run ${DOCKER_RUN_ARGS} \
            -v "${RECIPE_ROOT}":/home/conda/recipe_root:rw,z,delegated \

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,5 +1,5 @@
 BSD 3-clause license
-Copyright (c) 2015-2020, conda-forge contributors
+Copyright (c) 2015-2021, conda-forge contributors
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/README.md
+++ b/README.md
@@ -192,9 +192,9 @@ build distinct package versions.
 
 In order to produce a uniquely identifiable distribution:
  * If the version of a package **is not** being increased, please add or increase
-   the [``build/number``](https://conda.io/docs/user-guide/tasks/build-packages/define-metadata.html#build-number-and-string).
+   the [``build/number``](https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html#build-number-and-string).
  * If the version of a package **is** being increased, please remember to return
-   the [``build/number``](https://conda.io/docs/user-guide/tasks/build-packages/define-metadata.html#build-number-and-string)
+   the [``build/number``](https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html#build-number-and-string)
    back to 0.
 
 Feedstock Maintainers

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "mpb" %}
 {% set version = "1.11.1" %}
 {% set sha256 = "dc55b081c56079727dac92d309f8e4ea84ca6eea9122ec24b7955f8c258608e1" %}
-{% set buildnumber = 2 %}
+{% set buildnumber = 3 %}
 
 # recipe-lint fails if mpi is undefined
 {% set mpi = mpi or 'nompi' %}


### PR DESCRIPTION
The last deploy of this package failed randomly (https connection lost). https://github.com/conda-forge/mpb-feedstock/runs/1958833526

I'm re-rendering the feedstock as a way to re-trigger CI and re-deploy on merge.

This should help fix pymeep: https://github.com/conda-forge/pymeep-feedstock/pull/56

This PR can be merged when tests pass.

Failure log snippet:
```
Downloading source to cache: mpb-1.11.1_dc55b081c5.tar.gz
Downloading https://github.com/NanoComp/mpb/releases/download/v1.11.1/mpb-1.11.1.tar.gz
INFO:conda_build.source:Source cache directory is: /home/conda/feedstock_root/build_artifacts/src_cache
INFO conda_build.source:download_to_cache(44): Source cache directory is: /home/conda/feedstock_root/build_artifacts/src_cache
INFO:conda_build.source:Downloading source to cache: mpb-1.11.1_dc55b081c5.tar.gz
INFO conda_build.source:download_to_cache(69): Downloading source to cache: mpb-1.11.1_dc55b081c5.tar.gz
INFO:conda_build.source:Downloading https://github.com/NanoComp/mpb/releases/download/v1.11.1/mpb-1.11.1.tar.gz
INFO conda_build.source:download_to_cache(83): Downloading https://github.com/NanoComp/mpb/releases/download/v1.11.1/mpb-1.11.1.tar.gz
Error: HTTP 502 BAD GATEWAY for url <https://github.com/NanoComp/mpb/releases/download/v1.11.1/mpb-1.11.1.tar.gz>
Elapsed: 00:01.810865

An HTTP error occurred when trying to retrieve this URL.
HTTP errors are often intermittent, and a simple retry will get you on your way.
WARNING:conda_build.source:Error: HTTP 502 BAD GATEWAY for url <https://github.com/NanoComp/mpb/releases/download/v1.11.1/mpb-1.11.1.tar.gz>
Elapsed: 00:01.810865
```